### PR TITLE
fix: bin scripts tsx 경로를 require.resolve로 변경

### DIFF
--- a/bin/task-mcp.mjs
+++ b/bin/task-mcp.mjs
@@ -3,13 +3,16 @@
 import { spawn } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, "..");
 const entry = resolve(root, "src/mcp/index.ts");
-const tsx = resolve(root, "node_modules/.bin/tsx");
 
-const child = spawn(tsx, [entry], {
+const require = createRequire(import.meta.url);
+const tsx = require.resolve("tsx/cli");
+
+const child = spawn(process.execPath, [tsx, entry], {
   stdio: "inherit",
   cwd: process.cwd(),
 });

--- a/bin/task.mjs
+++ b/bin/task.mjs
@@ -3,14 +3,17 @@
 import { execFileSync } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, "..");
 const entry = resolve(root, "src/cli/index.ts");
-const tsx = resolve(root, "node_modules/.bin/tsx");
+
+const require = createRequire(import.meta.url);
+const tsx = require.resolve("tsx/cli");
 
 try {
-  execFileSync(tsx, [entry, ...process.argv.slice(2)], {
+  execFileSync(process.execPath, [tsx, entry, ...process.argv.slice(2)], {
     stdio: "inherit",
     cwd: process.cwd(),
   });


### PR DESCRIPTION
## Summary
- `bin/task.mjs`, `bin/task-mcp.mjs`에서 하드코딩된 `node_modules/.bin/tsx` 경로를 `createRequire` + `require.resolve("tsx/cli")`로 변경
- `process.execPath`로 Node.js 바이너리를 명시적으로 지정

Closes #1

## 변경 내용

**Before (broken):**
```js
const tsx = resolve(root, "node_modules/.bin/tsx");
execFileSync(tsx, [entry, ...args], { ... });
```

**After (fixed):**
```js
const require = createRequire(import.meta.url);
const tsx = require.resolve("tsx/cli");
execFileSync(process.execPath, [tsx, entry, ...args], { ... });
```

## 왜 이 방법인가

| 대안 | 문제 |
|------|------|
| `npx tsx` | 매 실행마다 npx 오버헤드, 버전 불일치 가능 |
| `which`/`where` 로 검색 | OS별 차이, PATH 의존 |
| 빌드 후 JS 배포 | 구조 변경이 큼 |
| **`require.resolve`** | Node.js 표준 모듈 해석, 확실하고 빠름 ✅ |

## Test plan
- [x] `npm install` 후 `node bin/task.mjs --help` 정상 출력 확인
- [ ] 별도 디렉토리에서 `npm install @kmgeon/taskflow` → `npx task init` 테스트 (publish 후)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 내부 스크립트 실행 메커니즘을 개선했습니다. `tsx` 바이너리 해결 방식을 업데이트하고 프로세스 호출 흐름을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->